### PR TITLE
Initialize ErrorManager based on RUN_MODE environment variable.

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -85,7 +85,7 @@ const LDAP_FIND_IS_ADMIN = null;
  * In production mode, errors are logged but not returned to callers.
  * In development mode, errors are logged as well as returned to callers.
  */
-const RUN_MODE = 'development'
+const RUN_MODE = 'development';
 
 /**
  * Randomly generated secret key

--- a/config.dist.php
+++ b/config.dist.php
@@ -79,6 +79,13 @@ const LDAP_FIND_USER = null;
 const LDAP_FIND_IS_ADMIN = null;
 //const LDAP_FIND_IS_ADMIN = '(&(|(objectclass=posixAccount))(uid=%s)(permission=cn=karadav.admin.main,ou=permission,dc=yunohost,dc=org))';
 
+/**
+ * Run mode dictates whether errors are returned to callers.
+ *
+ * In production mode, errors are logged but not returned to callers.
+ * In development mode, errors are logged as well as returned to callers.
+ */
+const RUN_MODE = 'development'
 
 /**
  * Randomly generated secret key

--- a/www/_inc.php
+++ b/www/_inc.php
@@ -9,7 +9,13 @@ spl_autoload_register(function ($class) {
     require_once __DIR__ . '/../lib/' . $class . '.php';
 });
 
-ErrorManager::enable(ErrorManager::DEVELOPMENT);
+if ($RUN_MODE == 'production') {
+        ErrorManager::enable(ErrorManager::PRODUCTION);
+}
+else {
+        ErrorManager::enable(ErrorManager::DEVELOPMENT);
+}
+
 ErrorManager::setLogFile(__DIR__ . '/../error.log');
 
 $cfg_file = __DIR__ . '/../config.local.php';

--- a/www/_inc.php
+++ b/www/_inc.php
@@ -9,13 +9,6 @@ spl_autoload_register(function ($class) {
     require_once __DIR__ . '/../lib/' . $class . '.php';
 });
 
-if (RUN_MODE == 'production') {
-        ErrorManager::enable(ErrorManager::PRODUCTION);
-}
-else {
-        ErrorManager::enable(ErrorManager::DEVELOPMENT);
-}
-
 ErrorManager::setLogFile(__DIR__ . '/../error.log');
 
 $cfg_file = __DIR__ . '/../config.local.php';
@@ -25,6 +18,13 @@ if (!file_exists($cfg_file)) {
 }
 
 require $cfg_file;
+
+if (RUN_MODE == 'production') {
+        ErrorManager::enable(ErrorManager::PRODUCTION);
+}
+else {
+        ErrorManager::enable(ErrorManager::DEVELOPMENT);
+}
 
 // Create random secret key
 if (!defined('KaraDAV\SECRET_KEY')) {

--- a/www/_inc.php
+++ b/www/_inc.php
@@ -9,7 +9,7 @@ spl_autoload_register(function ($class) {
     require_once __DIR__ . '/../lib/' . $class . '.php';
 });
 
-if ($RUN_MODE == 'production') {
+if (RUN_MODE == 'production') {
         ErrorManager::enable(ErrorManager::PRODUCTION);
 }
 else {


### PR DESCRIPTION
I'd like to deploy this in production, but don't want error backtraces to be readily available to anyone that encounters them.