### PR TITLE
Use an actual temporary storage location for uploaded files

### DIFF
--- a/lib/KaraDAV/Storage.php
+++ b/lib/KaraDAV/Storage.php
@@ -264,7 +264,7 @@ class Storage extends AbstractStorage
 		$size = 0;
 		$quota = $this->users->quota($this->users->current());
 
-		$tmp_file = '.tmp.' . sha1($target);
+		$tmp_file = '/tmp/.tmp.' . sha1($target);
 		$out = fopen($tmp_file, 'w');
 
 		while (!feof($pointer)) {


### PR DESCRIPTION
Hello,

I made this pull request so the PHP script would use the `/tmp` location when uploading some files instead of putting them in the directory of the `Storage.php` script file.

Feel free to edit this MR if more locations should be added.