### PR TITLE
Fix docker permission issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,12 @@ RUN mkdir /var/karadav/data
 RUN mkdir /var/karadav/lib
 RUN mkdir /var/karadav/www
 
-RUN chown -R nobody.nobody /var/karadav
-
-USER nobody
-
 # Add application
 WORKDIR /var/karadav/
-COPY --chown=nobody lib /var/karadav/lib/
-COPY --chown=nobody www /var/karadav/www/
-COPY --chown=nobody schema.sql /var/karadav/
-COPY --chown=nobody config.dist.php /var/karadav/config.local.php
+COPY lib /var/karadav/lib/
+COPY www /var/karadav/www/
+COPY schema.sql /var/karadav/
+COPY config.dist.php /var/karadav/config.local.php
 
 EXPOSE 8080
 

--- a/www/_inc.php
+++ b/www/_inc.php
@@ -90,10 +90,14 @@ if (!defined('KaraDAV\DISABLE_SLOW_OPERATIONS')) {
 
 // Init database
 if (!file_exists(DB_FILE)) {
+	$created = touch(DB_FILE);
+	if (!$created) {
+	    throw new \RuntimeException('Failed to create database file');
+	}
+	
 	$db = DB::getInstance();
 	$db->exec('BEGIN;');
 	$db->exec(file_get_contents(__DIR__ . '/../schema.sql'));
-
 	if (!LDAP::enabled()) {
 		$users = new Users;
 		$p = 'karadavdemo';


### PR DESCRIPTION
This PR aims to fix #30.
By using the default Docker user instead of the previously used `nobody`, the container can write inside the data directory mounted as a volume without the need for changes to the directory's permission.
This PR also adds a bit of basic PHP error handling that warns if the database can't be created on first run.
I haven't used PHP in a long time, so tell me if this is not the correct way to handle this :) It does work though.