### PR TITLE
ldap: fix a typo in a constant name

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -115,7 +115,7 @@ const AUTH_CALLBACK = null;
  *
  * All users logging in will be created locally and have the default quota.
  */
-const LDAP_HOST = null;
+const LDAP_URI = null;
 //const LDAP_URI = '127.0.0.1';
 
 const LDAP_LOGIN = null;


### PR DESCRIPTION
the `LDAP_URI` was named `LDAP_HOST` so i just wrecked my head for 2 hours x)
the example comment is right, tho

the error:
![screenshot of the error](https://github.com/kd2org/karadav/assets/6963387/41ddd042-93be-4327-90e6-67cb84386940)
