### PR TITLE
Fix nginx config for Nextcloud clients

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -84,6 +84,7 @@ server {
     }
 
     location ~* \.php$ {
+        try_files $uri $uri/ /_router.php?$query_string;
         fastcgi_pass unix:/run/php-fpm/www.sock;
         include fastcgi_params;
         fastcgi_index index.php;


### PR DESCRIPTION
This was a stupid error that prevented Nextcloud clients from connecting as /nextcoud/status.php was returning 404.