### PR TITLE
docker: fix cmd not working without php symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ EXPOSE 8080
 VOLUME ["/var/karadav/data", "/var/karadav/config.local.php"]
 
 ENV PHP_CLI_SERVER_WORKERS=3
-CMD ["php", "-S", "0.0.0.0:8080", "-t", "www", "www/_router.php"]
+CMD ["php82", "-S", "0.0.0.0:8080", "-t", "www", "www/_router.php"]


### PR DESCRIPTION
This fixes #58

Alpine only symlinks the most recent PHP version (8.3) to the php package now in order and not older versions. As we probably want to keep setting the PHP version ourselves, the best way probably is to specify the php version in the `CMD` command and change it when updating PHP in the Dockerfile.

Awesome project btw!