### PR TITLE
Fix chunked uploads (https://github.com/kd2org/karadav/issues/60)

### DIFF
--- a/lib/KD2/WebDAV/NextCloud.php
+++ b/lib/KD2/WebDAV/NextCloud.php
@@ -256,6 +256,10 @@ abstract class NextCloud
 		'index.php/login/v2/poll' => 'poll',
 		'index.php/login/v2' => 'login_v2',
 
+		// NC connectivity check (uploads on Android fail without this)
+		// see, e.g., https://github.com/nextcloud/android/issues/10993
+		'index.php/204' => 'ping',
+
 		// Other API endpoints
 		'index.php/core/preview.png' => 'preview',
 		'index.php/apps/files/api/v1/thumbnail/' => 'thumbnail',
@@ -502,6 +506,11 @@ abstract class NextCloud
 			'loginName'   => $session['login'],
 			'appPassword' => $session['password'],
 		];
+	}
+
+	public function nc_ping()
+	{
+		http_response_code(204);
 	}
 
 	public function nc_capabilities()

--- a/lib/KD2/WebDAV/NextCloud.php
+++ b/lib/KD2/WebDAV/NextCloud.php
@@ -790,20 +790,17 @@ abstract class NextCloud
 		}
 
 		$method = $_SERVER['REQUEST_METHOD'] ?? null;
-		$login = $match[1] ?? null;
+		// Clients nowadays send some user ID as login, just ignore it.
+		// $login = $match[1] ?? null;
 		$dir = $match[2] ?? null;
 		$part = $match[3] ?? null;
-
-		if ($login !== $user) {
-			throw new Exception('Invalid username in URL, does not match logged user', 403);
-		}
 
 		if ($method == 'MKCOL') {
 			http_response_code(201);
 		}
 		elseif ($method == 'PUT') {
-			$this->server->log('Storing chunk: %s/%s/%s', $login, $dir, $part);
-			$this->storeChunk($login, $dir, $part, fopen('php://input', 'rb'));
+			$this->server->log('Storing chunk: %s/%s/%s', $user, $dir, $part);
+			$this->storeChunk($user, $dir, $part, fopen('php://input', 'rb'));
 			http_response_code(201);
 		}
 		elseif ($method == 'MOVE') {
@@ -821,13 +818,10 @@ abstract class NextCloud
 
 			header('X-OC-MTime: accepted');
 
+			$return = $this->assembleChunks($user, $dir, $dest, $mtime);
+
 			$props = $this->storage->propfind($dest, [self::PROP_OC_ID], 0);
-
-			if (count($props)) {
-				header('OC-FileId: ' . current($props));
-			}
-
-			$return = $this->assembleChunks($login, $dir, $dest, $mtime);
+			header('OC-FileId: ' . current($props));
 
 			if (!empty($return['etag'])) {
 				header(sprintf('ETag: "%s"', $return['etag']));
@@ -844,7 +838,7 @@ abstract class NextCloud
 			}
 		}
 		elseif ($method == 'DELETE' && !$part) {
-			$this->deleteChunks($login, $dir);
+			$this->deleteChunks($user, $dir);
 			$this->server->log("=> Deleted chunks");
 		}
 		elseif ($method == 'PROPFIND') {
@@ -852,7 +846,7 @@ abstract class NextCloud
 			$out = '<?xml version="1.0" encoding="utf-8"?>' . PHP_EOL;
 			$out .= '<d:multistatus xmlns:d="DAV:">' . PHP_EOL;
 
-			foreach ($this->listChunks($login, $dir) as $chunk) {
+			foreach ($this->listChunks($user, $dir) as $chunk) {
 				$out .= '<d:response>' . PHP_EOL;
 				$chunk = '/' . $uri . '/' . $chunk;
 				$out .= sprintf('<d:href>%s</d:href>', htmlspecialchars($chunk, ENT_XML1)) . PHP_EOL;


### PR DESCRIPTION
- Nextcloud and Owncloud clients use some userID instead of the username in their WebDAV queries.
- The /uploads endpoint checked this path segment against the user name and thus returned "403 - Forbidden" when trying to upload larger files.
- Remove this check and ignore the username path-segment for the /uploads endpoint, as was already the case for queries to /files.
- Fix error calling `count($props=null)` by `propfind()`-ing the uploaded file only after it has been assembled and moved to its destination.