### PR TITLE
Fix uploads in Nextcloud Android 3.30.4 failing with connection error

### DIFF
--- a/lib/KD2/WebDAV/NextCloud.php
+++ b/lib/KD2/WebDAV/NextCloud.php
@@ -256,6 +256,10 @@ abstract class NextCloud
 		'index.php/login/v2/poll' => 'poll',
 		'index.php/login/v2' => 'login_v2',
 
+		// NC connectivity check (uploads on Android fail without this)
+		// see, e.g., https://github.com/nextcloud/android/issues/10993
+		'index.php/204' => 'ping',
+
 		// Other API endpoints
 		'index.php/core/preview.png' => 'preview',
 		'index.php/apps/files/api/v1/thumbnail/' => 'thumbnail',
@@ -502,6 +506,11 @@ abstract class NextCloud
 			'loginName'   => $session['login'],
 			'appPassword' => $session['password'],
 		];
+	}
+
+	public function nc_ping()
+	{
+		http_response_code(204);
 	}
 
 	public function nc_capabilities()


### PR DESCRIPTION
Before upload operations, the Nextcloud Android app checks whether it can reach the server by querying index.php/204 and aborts the upload when it receives no response (or an 404 error from karadav, apparently).
Implement this endpoint in karadav and just return status 204.