### PR TITLE
 Fix: Define missing $current variable to prevent PHP warnings on login page

### DIFF
--- a/www/_inc.php
+++ b/www/_inc.php
@@ -25,6 +25,10 @@ $tpl->setCompiledDir(CACHE_PATH . '/compiled');
 
 $tpl->assign('www_url', WWW_URL);
 $tpl->assign('apps', EXTERNAL_APPS);
+
+$current = ($file === 'app.php') ? ($_GET['app'] ?? null) : basename($file, '.php');
+$tpl->assign('current', $current);
+
 $tpl->assign(compact('logged_user', 'users'));
 
 $tpl->register_function('form_csrf', function (): string {


### PR DESCRIPTION
When accessing the login page, the `_header.tpl` template checks the `$current` variable to highlight the active menu item. However, this variable was never actually defined in the PHP backend. 
On PHP 8.0+, this throws a strict `Warning: Undefined variable $current`, which breaks the template rendering and blocks the Nextcloud client OAuth login flow. This fix simply defines and assigns `$current` in `www/_inc.php` dynamically based on the active file or app.