### PR TITLE
Fix: SQLite root folder matching, invalid XML keys, quota, and creationdate formats

### DIFF
--- a/lib/KD2/WebDAV/NextCloud.php
+++ b/lib/KD2/WebDAV/NextCloud.php
@@ -433,6 +433,10 @@ abstract class NextCloud
 		$out = '';
 
 		foreach ($array as $key => $v) {
+			if (is_int($key)) {
+				$key = 'element';
+			}
+
 			$out .= '<' . $key .'>';
 
 			if (is_array($v)) {

--- a/lib/KD2/WebDAV/Server.php
+++ b/lib/KD2/WebDAV/Server.php
@@ -800,7 +800,7 @@ class Server
 				// see https://github.com/opencloud-eu/android/issues/74
 				if ($name == 'DAV::creationdate'
 					&& ($value instanceof \DateTimeInterface)
-					&& false !== preg_match('/owncloud|opencloud/', $_SERVER['HTTP_USER_AGENT'] ?? '')) {
+					&& preg_match('/(owncloud|opencloud).*android/i', $_SERVER['HTTP_USER_AGENT'] ?? '')) {
 					$value = $value->getTimestamp();
 				}
 				// ownCloud app crashes if mimetype is provided for a directory
@@ -820,7 +820,11 @@ class Server
 					// Change value to GMT
 					$value = clone $value;
 					$value->setTimezone(new \DateTimeZone('GMT'));
-					$value = $value->format(self::DATE_RFC7231);
+					if ($name === 'DAV::creationdate') {
+						$value = $value->format('Y-m-d\TH:i:s\Z');
+					} else {
+						$value = $value->format(self::DATE_RFC7231);
+					}
 				}
 				elseif (is_array($value)) {
 					$attributes = $value['attributes'] ?? '';

--- a/lib/KaraDAV/DB.php
+++ b/lib/KaraDAV/DB.php
@@ -76,7 +76,8 @@ class DB extends \SQLite3
 
 	public function getPathLikeExpression(string $path)
 	{
-		return str_replace(['?', '%'], ['\\?', '\\%'], $path) . '/%';
+		$path = str_replace(['?', '%'], ['\\?', '\\%'], $path);
+		return $path === '' ? '%' : $path . '/%';
 	}
 
 	public function upgradeVersion(): void

--- a/lib/KaraDAV/Storage.php
+++ b/lib/KaraDAV/Storage.php
@@ -185,7 +185,7 @@ class Storage extends AbstractStorage implements TrashInterface
 				return is_dir($target) ? 'collection' : '';
 			case 'DAV::getlastmodified':
 				if (!$uri && $depth == 0 && is_dir($target)) {
-					$mtime = $this->getRecursiveFileProperty($uri, 'modified');
+					$mtime = $this->getRecursiveFileProperty($uri, 'modified') ?: filemtime($target);
 				}
 				else {
 					$mtime = filemtime($target);
@@ -288,12 +288,12 @@ class Storage extends AbstractStorage implements TrashInterface
 
 				return $this->getTrashInfo(basename($uri))['Path'] ?? null;
 			case 'DAV::quota-available-bytes':
-				return null;
+				return $this->users->quota($this->users->current())->free;
 			case 'DAV::quota-used-bytes':
-				return null;
+				return $this->users->quota($this->users->current())->used;
 			case Nextcloud::PROP_OC_SIZE:
 				if (is_dir($target)) {
-					return $this->getRecursiveFileProperty($uri, 'size');
+					return (int) $this->getRecursiveFileProperty($uri, 'size');
 				}
 				else {
 					return self::getFilesize($target);


### PR DESCRIPTION
This PR resolves several silent errors and edge cases to improve overall client compatibility (especially for ownCloud/Nextcloud Desktop & Android Clients and strict WebDAV implementations).
While the ownCloud client is forgiving enough to continue syncing without some of these properties, it currently triggers internal 404 errors and drops features (like displaying available server space or correct creation dates).
**1. SQLite root path bug (`DB::getPathLikeExpression`)**
The method generated `LIKE '/%'` for the root directory. Since paths are stored without leading slashes in the database, this matched 0 files. Consequently, recursive property lookups for the root folder failed. It now correctly returns `LIKE '%'` for the root directory.
**2. Storage Fallbacks and Quota (`Storage::propfind`)**
- `DAV::quota-available-bytes` / `quota-used-bytes`: Previously returned `null`, which resulted in a `404 Not Found` response. By returning the actual quota values, Desktop Clients can now successfully display the used/free space in their UI and warn users before uploading files that exceed the server's capacity.
- `DAV::getlastmodified`: If a folder (like root) was empty or failed the SQL lookup, it returned a 404. It now falls back to `filemtime($target)`, ensuring strict native WebDAV clients (which demand a folder date) don't fail.
**3. Invalid XML tags (`NextCloud::toXML`)**
When encountering numeric arrays, the XML generator created tags starting with numbers (e.g., `<0>`). Since this violates the XML specification, it can cause crashes in strict Qt-based XML parsers. It now falls back to `<element>` for numeric keys.
**4. Creationdate formatting & Android workaround (`Server::route` / propfind)**
- The previous workaround for the ownCloud Android app (`preg_match('/owncloud|opencloud/')`) was too broad and accidentally affected the Desktop client, causing it to receive raw integer timestamps. The regex is now correctly restricted to `.*android`.
- For standard clients, the `DAV::creationdate` property is now properly formatted as an ISO 8601 string (`Y-m-d\TH:i:s\Z`) as required by WebDAV RFC 4918, instead of the generic RFC 7231 date format used for `getlastmodified`.