### PR TITLE
Fix: critical bugs in NextCloud chunked upload handling

### DIFF
--- a/lib/KaraDAV/NextCloud.php
+++ b/lib/KaraDAV/NextCloud.php
@@ -122,10 +122,13 @@ class NextCloud extends WebDAV_NextCloud
 	{
 		$expire = time() - 36*3600;
 
-		foreach (glob($this->temporary_chunks_path . '/*/*') as $dir) {
-			$first_file = current(glob($dir . '/*'));
+		foreach (glob($this->temporary_chunks_path . '/*/*') ?: [] as $dir) {
+			$first_file = current(glob($dir . '/*') ?: []);
 
-			if (filemtime($first_file) < $expire) {
+			if ($first_file && filemtime($first_file) < $expire) {
+				Storage::deleteDirectory($dir);
+			}
+			elseif (!$first_file && filemtime($dir) < $expire) {
 				Storage::deleteDirectory($dir);
 			}
 		}
@@ -145,9 +148,9 @@ class NextCloud extends WebDAV_NextCloud
 
 		while (!feof($pointer)) {
 			$data = fread($pointer, 8192);
-			$used += strlen($used);
+			$used += strlen($data);
 
-			if ($used > $quota['free']) {
+			if ($used > $quota['total']) {
 				$this->deleteChunks($login, $name);
 				throw new WebDAV_Exception('Your quota does not allow for the upload of this file', 403);
 			}
@@ -161,8 +164,8 @@ class NextCloud extends WebDAV_NextCloud
 
 	public function listChunks(string $login, string $name): array
 	{
-		$path = $this->temporary_chunks_path . '/' . $name;
-		$list = glob($path . '/*');
+		$path = $this->temporary_chunks_path . '/' . $login . '/' . $name;
+		$list = glob($path . '/*') ?: [];
 		$list = array_map(fn($a) => str_replace($path . '/', '', $a), $list);
 		return $list;
 	}
@@ -191,7 +194,10 @@ class NextCloud extends WebDAV_NextCloud
 
 		$out = fopen($target, 'wb');
 
-		foreach (glob($path . '/*') as $file) {
+		$chunks = glob($path . '/*') ?: [];
+		natsort($chunks);
+
+		foreach ($chunks as $file) {
 			$in = fopen($file, 'rb');
 
 			while (!feof($in)) {


### PR DESCRIPTION
## Summary
Fixes multiple bugs in `NextCloud.php` that caused chunked file uploads (used by ownCloud/Nextcloud desktop clients for files >10MB) to fail with `403 Forbidden`.
## Bugs Fixed
### 1. Incorrect byte counting in `storeChunk()` (critical)
`$used += strlen($used)` counted the string length of the *accumulator variable* (e.g. `"12345"` → 5 bytes) instead of the actual chunk data. Fixed to `strlen($data)`.
### 2. Wrong quota comparison in `storeChunk()` (critical)
The quota check compared accumulated usage against `$quota['free']` (remaining space), but `$used` already includes `$quota['used']`. This double-counted existing usage, causing uploads to fail for any user over ~50% capacity. Fixed to compare against `$quota['total']`.
### 3. Missing `$login` path segment in `listChunks()`
The chunk directory was constructed as `_chunks/$name` instead of `_chunks/$login/$name`, causing `PROPFIND` requests during upload resume to return empty results.
### 4. Unsafe `glob()` calls causing PHP 8 TypeErrors
`glob()` returns `false` (not `[]`) on failure. Passing `false` to `foreach`, `array_map`, or `natsort` causes fatal `TypeError` exceptions in PHP 8. All `glob()` calls are now safeguarded with `?: []`.
### 5. Missing natural sort in `assembleChunks()`
Chunks were assembled using `glob()` default (alphabetical) ordering, which sorts `1, 10, 2` incorrectly for non-zero-padded names. Added `natsort()` to ensure correct file reconstruction.
### 6. Crash in `cleanChunks()` on empty directories
`current(glob($dir . '/*'))` returns `false` for empty directories, and `filemtime(false)` triggers a PHP warning. Added proper handling for both populated and empty expired chunk directories.