### PR TITLE
fix: include hidden files (dotfiles) in WebDAV directory listings

### DIFF
--- a/lib/KaraDAV/Storage.php
+++ b/lib/KaraDAV/Storage.php
@@ -101,12 +101,22 @@ class Storage extends AbstractStorage implements TrashInterface
 
 	public function list(string $uri, ?array $properties): iterable
 	{
-		$dirs = self::glob($this->users->current()->path . $uri, '/*', \GLOB_ONLYDIR);
+		$path = $this->users->current()->path . $uri;
+
+		$dirs = array_merge(
+			self::glob($path, '/*', \GLOB_ONLYDIR),
+			self::glob($path, '/.*', \GLOB_ONLYDIR)
+		);
 		$dirs = array_map('basename', $dirs);
+		$dirs = array_diff($dirs, ['.', '..', '.trash']);
 		natcasesort($dirs);
 
-		$files = self::glob($this->users->current()->path . $uri, '/*');
+		$files = array_merge(
+			self::glob($path, '/*'),
+			self::glob($path, '/.*')
+		);
 		$files = array_map('basename', $files);
+		$files = array_diff($files, ['.', '..', '.trash']);
 		$files = array_diff($files, $dirs);
 		natcasesort($files);
 


### PR DESCRIPTION
PHP's glob() function excludes files starting with a dot by default, which caused all hidden files (e.g. .ssh, .htaccess, .gitignore) to be invisible in WebDAV PROPFIND responses. This made sync clients like ownCloud/NextCloud immediately delete such files after upload, as they appeared to no longer exist on the server.

Fix: also call glob('/.*') in the list() method to include hidden files and directories. Explicitly filter out the internal .trash directory so it stays invisible.

Note: the suggested fix is generated by AI.