### PR TITLE
fix: compute directory Depth-0 ETag from file cache table

### DIFF
--- a/lib/KaraDAV/Storage.php
+++ b/lib/KaraDAV/Storage.php
@@ -241,7 +241,7 @@ class Storage extends AbstractStorage implements TrashInterface
 			case 'DAV::ishidden':
 				return basename($target)[0] == '.';
 			case 'DAV::getetag':
-				if ($depth) {
+				if ($depth || is_dir($target)) {
 					$hash = $this->getRecursiveFileProperty($uri, 'modified')
 						. $this->getRecursiveFileProperty($uri, 'size');
 				}


### PR DESCRIPTION
**Problem:** The ownCloud/NextCloud desktop client polls for changes via `PROPFIND Depth: 0` on the root directory, comparing the ETag. If the ETag hasn't changed, it skips the full `Depth: 1` listing. The Depth-0 ETag for directories was computed from `filemtime()` of the directory itself, which only updates when a direct child changes – not when files are added/removed in deeply nested subfolders.

**Impact:**
External changes in deeply nested folders were missed by the desktop client's change detection, because the root directory ETag did not update.

**Fix:** When computing the Depth-0 ETag for a directory, use the same database-backed recursive property lookup (`MAX(modified)`, `SUM(size)` from the `files` table) that is already used for `Depth > 0` and for the `getlastmodified` property. This ensures the ETag reflects changes at any nesting level.

**Note:** The suggested fix is generated by AI. The fix has been tested and is working.